### PR TITLE
refactor: change default brotli compression level to 4

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Refer to the zstd [manual](https://facebook.github.io/zstd/zstd_manual.html) for
 
 #### brotliLevel
 
-Defaults to `11`.
+Defaults to `4`.
 
 Brotli algorithm compression level.
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -6,7 +6,7 @@ export const NODE_ENCODINGS = ['br', 'gzip', 'deflate'] as const
 
 export const CACHECONTROL_NOTRANSFORM_REGEXP = /(?:^|,)\s*?no-transform\s*?(?:,|$)/i
 
-export const THRESHOLD_SIZE = 1024 as const
-export const ZSTD_LEVEL = 2 as const
-export const BROTLI_LEVEL = 11 as const
-export const ZLIB_LEVEL = 6 as const
+export const THRESHOLD_SIZE = 1024
+export const ZSTD_LEVEL = 2
+export const BROTLI_LEVEL = 4
+export const ZLIB_LEVEL = 6


### PR DESCRIPTION
A default compression level of 11 is likely too extreme/slow for most use cases.

Cloudflare recommends a default of 4 https://blog.cloudflare.com/this-is-brotli-from-origin/#brotli-compression-to-11

the fastify-compress plugin changed their default based on this recommendation too https://github.com/fastify/fastify-compress/issues/287#issuecomment-2025071956